### PR TITLE
chore: sync fork with upstream (dynamic blocks & project_title)

### DIFF
--- a/src/lib/define-dynamic-block.js
+++ b/src/lib/define-dynamic-block.js
@@ -97,10 +97,26 @@ const defineDynamicBlock = (ScratchBlocks, categoryInfo, staticBlockInfo, extend
             const arg = blockInfo.arguments[argName];
             switch (arg.type) {
             case ArgumentType.STRING:
+            case ArgumentType.NUMBER:
+            case ArgumentType.ANGLE:
+            case ArgumentType.MATRIX:
+            case ArgumentType.NOTE:
+            case ArgumentType.COLOR:
+            case ArgumentType.COSTUME:
+            case ArgumentType.SOUND:
                 args.push({type: 'input_value', name: argName});
                 break;
             case ArgumentType.BOOLEAN:
                 args.push({type: 'input_value', name: argName, check: 'Boolean'});
+                break;
+            case ArgumentType.IMAGE:
+                args.push({
+                    type: 'field_image',
+                    src: arg.dataURI || '',
+                    width: 24,
+                    height: 24,
+                    flip_rtl: arg.flipRTL || false
+                });
                 break;
             }
             return `%${++argCount}`;

--- a/src/lib/titled-hoc.jsx
+++ b/src/lib/titled-hoc.jsx
@@ -33,8 +33,8 @@ const TitledHOC = function (WrappedComponent) {
             // if project is a new default project, and has loaded,
             if (this.props.isShowingWithoutId && prevProps.isAnyCreatingNewState) {
                 // reset title to default
-                const defaultProjectTitle = this.handleReceivedProjectTitle();
-                this.props.onUpdateProjectTitle(defaultProjectTitle, true);
+                const {title, isDefault} = this.handleReceivedProjectTitle();
+                this.props.onUpdateProjectTitle(title, isDefault);
             }
             // if the projectTitle hasn't changed, but the reduxProjectTitle
             // HAS changed, we need to report that change to the projectTitle's owner
@@ -51,11 +51,20 @@ const TitledHOC = function (WrappedComponent) {
             let newTitle = requestedTitle;
             let isDefault = false;
             if (newTitle === null || typeof newTitle === 'undefined') {
-                newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);
-                isDefault = true;
+                const urlTitle = typeof URLSearchParams !== 'undefined' &&
+                    new URLSearchParams(location.search).get('project_title');
+                if (urlTitle) {
+                    newTitle = urlTitle;
+                } else {
+                    newTitle = this.props.intl.formatMessage(messages.defaultProjectTitle);
+                    isDefault = true;
+                }
             }
             this.props.onChangedProjectTitle(newTitle, isDefault);
-            return newTitle;
+            return {
+                title: newTitle,
+                isDefault
+            };
         }
         render () {
             const {


### PR DESCRIPTION
## 变更说明

本 PR 将 fork 同步至上游最新提交

### 已同步的上游提交
- `Added support for more argument types for dynamic extension blocks`（Mythylvia, GarboMuffin · 6月8日）
- `Support project_title parameter`（bddjr · TurboWarp#1166 · 6月28日）

### 关联
Ref: TurboWarp#1166